### PR TITLE
Improve forecast dashboard

### DIFF
--- a/client/components/WeatherChart.vue
+++ b/client/components/WeatherChart.vue
@@ -107,8 +107,8 @@ const createD3Chart = () => {
     .style('fill', '#9E9E9E') // Dark mode text color
     .text(props.chartData.axis_labels.yAxis);
 
-  // Define color scale with pale green accent
-  const colorPalette = ['#8BC34A', '#A4D070', '#689F38', '#558B2F', '#33691E'];
+  // Define color scale with modern blue accent
+  const colorPalette = ['#3B82F6', '#60A5FA', '#2563EB', '#1D4ED8', '#1E40AF'];
   const color = d3.scaleOrdinal(colorPalette);
 
   // Create line generator

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -8,20 +8,39 @@
     </div>
     <div class="flex justify-center mt-4">
       <div class="w-full">
-        <div class="alert-info mb-4">
-          <i class="fas fa-info-circle text-accent"></i> Full weather dashboard coming soon!
-        </div>
-
         <div v-if="data" class="bg-dark-card border border-dark-border rounded-lg shadow-md mb-4 overflow-hidden">
           <div class="p-6">
-            <h2 class="text-xl font-bold mb-2 text-dark-primary">Boulder, Colorado Weather Data</h2>
-            <!-- D3 Charts -->
+            <h2 class="text-xl font-bold mb-4 text-dark-primary">Boulder, Colorado Weather Data</h2>
+
+            <!-- Day Tabs -->
+            <div class="flex space-x-2 mb-6">
+              <button
+                v-for="(day, index) in days"
+                :key="day.label"
+                class="px-3 py-1 rounded focus:outline-none"
+                :class="index === activeDay ? 'bg-accent text-white' : 'bg-dark-lighter text-dark-primary'"
+                @click="activeDay = index"
+              >
+                {{ day.label }}
+              </button>
+            </div>
+
+            <!-- Climbing Fun Chart -->
             <WeatherChart
-              v-for="chart in data?.charts || []"
-              :key="chart.id"
-              :chart-id="chart.id"
-              :chart-data="chart"
+              v-if="funChart"
+              :chart-id="`fun_chart_${activeDay}`"
+              :chart-data="funChart"
             />
+
+            <!-- Other Charts -->
+            <div class="grid gap-6 md:grid-cols-2">
+              <WeatherChart
+                v-for="chart in otherCharts"
+                :key="`${chart.id}_${activeDay}`"
+                :chart-id="`${chart.id}_${activeDay}`"
+                :chart-data="chart"
+              />
+            </div>
           </div>
         </div>
 
@@ -35,6 +54,7 @@
 
 <script setup lang="ts">
 // Using script setup for Composition API
+import { ref, computed } from 'vue'
 useHead({
   title: 'Climbing Forecast - Welcome'
 })
@@ -51,4 +71,43 @@ const { data, error } = useFetch('/api/weather/data', {
     utc_offset: -7
   })
 })
+
+const activeDay = ref(0)
+
+const days = computed(() => {
+  if (!data.value) return []
+  const uniqueDays: { label: string; indices: number[] }[] = []
+  const dayValues = data.value.time.day
+  const months = data.value.time.month
+  const locals = data.value.time.local
+
+  const dayMap: Record<string, number[]> = {}
+  dayValues.forEach((d, i) => {
+    const key = `${months[i]}-${d}`
+    if (!dayMap[key]) dayMap[key] = []
+    dayMap[key].push(i)
+  })
+
+  return Object.keys(dayMap).map(key => {
+    const idxs = dayMap[key]
+    const label = new Date(locals[idxs[0]]).toLocaleDateString(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric'
+    })
+    return { label, indices: idxs }
+  })
+})
+
+const dayCharts = computed(() => {
+  if (!data.value) return []
+  const day = days.value[activeDay.value]
+  if (!day) return []
+  return data.value.charts.map(c => ({
+    ...c,
+    labels: day.indices.map(i => c.labels[i]),
+    rows: c.rows.map(row => day.indices.map(i => row[i]))
+  }))
+})
+
+const funChart = computed(() => dayCharts.value.find(c => c.id === 'fun_chart'))
+const otherCharts = computed(() => dayCharts.value.filter(c => c.id !== 'fun_chart'))
 </script>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -13,14 +13,14 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#8BC34A', // Pale green as primary color
-          hover: '#7CB342',
-          border: '#689F38'
+          DEFAULT: '#3B82F6', // Modern blue as primary color
+          hover: '#2563EB',
+          border: '#1E40AF'
         },
         accent: {
-          DEFAULT: '#8BC34A', // Pale green accent
-          light: '#A4D070',
-          dark: '#689F38'
+          DEFAULT: '#3B82F6', // Modern blue accent
+          light: '#60A5FA',
+          dark: '#1D4ED8'
         },
         dark: {
           DEFAULT: '#1E1E1E', // Dark background


### PR DESCRIPTION
## Summary
- modernize color palette
- add day-based tabs and highlight fun chart
- update color scheme for charts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in `client` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862043142a8832699ea86bc5dfe6e52